### PR TITLE
Add catch-all command to proxy unrecognized git commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # GitPT
 
-Git Prompt Tool is a CLI tool that helps you write commit messages using AI through [OpenRouter](https://openrouter.ai/).
+Git Prompt Tool is a CLI tool that helps you write commit messages using AI through [OpenRouter](https://openrouter.ai/). It acts as a complete git wrapper, enhancing specific commands with AI while passing through all other git commands directly.
 
 ## Features
 
+- Acts as a complete git replacement - all git commands are supported
 - Generate commit messages with AI based on your code changes
 - Create pull requests with AI-generated titles and descriptions
-- Compatible with all regular git commit options (you can treat it as an alias)
+- Compatible with all regular git options (flags, arguments, etc.)
 - Edit suggested messages before committing
 - Works with various AI models via OpenRouter
 
@@ -36,16 +37,36 @@ You'll need an [OpenRouter](https://openrouter.ai/) account to get an API key.
 
 ## Usage
 
-### Adding Files
+### Using GitPT as a Complete Git Replacement
 
-Add files to the staging area using either git directly or the GitPT wrapper:
+GitPT can be used as a direct replacement for git - any git command can be run through GitPT:
 
 ```bash
-# Standard git command
-git add .
+# Standard git commands work exactly the same
+gitpt status
+gitpt log
+gitpt branch
+gitpt checkout -b new-feature
+gitpt push origin main
 
-# Or using GitPT wrapper
+# GitPT passes all arguments and options to git
+gitpt log --oneline --graph
+gitpt merge --no-ff feature-branch
+```
+
+### Adding Files
+
+Add files to the staging area just like you would with git:
+
+```bash
+# Same as git add .
 gitpt add .
+
+# Same as git add -p
+gitpt add -p
+
+# Same as git add src/*.ts
+gitpt add src/*.ts
 ```
 
 ### Creating Commits
@@ -128,11 +149,15 @@ gitpt pr create --title "Your PR title here"
 
 ## How It Works
 
-GitPT leverages AI via OpenRouter to enhance your Git workflow:
+GitPT leverages AI via OpenRouter to enhance your Git workflow while acting as a complete git wrapper:
+
+- **Command Handling:** GitPT intelligently routes commands - enhanced commands (commit, pr) use AI capabilities while all other git commands are passed directly to git.
 
 - **For commits:** Sends a diff of your staged changes to the AI, which generates a contextual commit message following best practices.
 
 - **For pull requests:** Analyzes the commits and file changes between your branch and the base branch, then generates a suitable title and detailed description for your PR.
+
+- **For other git commands:** Passes them through directly to git with all arguments and options preserved, ensuring complete compatibility with your existing git workflow.
 
 ## Development
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,27 +64,24 @@ program
   .allowUnknownOption(true)
   .action(prCreateCommand);
 
-// Default command handler for all other git commands
-program
-  .command('*', { hidden: true }) // Catch-all command that won't show in help
-  .allowUnknownOption(true)
-  .action((cmd, options) => {
-    if (!isGitRepository()) {
-      console.error(chalk.red('Error: Not a git repository'));
-      process.exit(1);
-    }
+// Handle unknown commands by passing them to git
+program.on('command:*', (operands) => {
+  if (!isGitRepository()) {
+    console.error(chalk.red('Error: Not a git repository'));
+    process.exit(1);
+  }
+  
+  try {
+    // Get all arguments passed to the original command
+    const args = process.argv.slice(2);
     
-    try {
-      // Get all arguments passed to the original command
-      const args = process.argv.slice(2);
-      
-      // Execute git with all arguments
-      execSync(`git ${args.join(' ')}`, { stdio: 'inherit' });
-    } catch (error) {
-      // Git will handle its own error output through stdio: 'inherit'
-      process.exit(1);
-    }
-  });
+    // Execute git with all arguments
+    execSync(`git ${args.join(' ')}`, { stdio: 'inherit' });
+  } catch (error) {
+    // Git will handle its own error output through stdio: 'inherit'
+    process.exit(1);
+  }
+});
 
 // Main logic
 async function main() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 
 import { Command } from 'commander';
 import chalk from 'chalk';
+import { execSync } from 'child_process';
 import { setupCommand } from './commands/setup.js';
 import { commitCommand } from './commands/commit.js';
 import { addCommand } from './commands/add.js';
@@ -10,6 +11,7 @@ import { prCreateCommand } from './commands/pr.js';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { isGitRepository } from './utils/git.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -23,19 +25,24 @@ program
   .description('Git Prompt Tool helps you write commit messages using AI')
   .version(version);
 
-// Setup command
+// GitPT-specific commands
 program
   .command('setup')
   .description('Configure GitPT with your OpenRouter API key and model selection')
   .action(setupCommand);
 
-// Add command (pass-through to git add)
+program
+  .command('model [model-id]')
+  .description('Change the AI model used for generating commit messages')
+  .action(modelCommand);
+
+// Enhanced git commands
 program
   .command('add [files...]')
   .description('Add files to git staging area (pass-through to git add)')
+  .allowUnknownOption(true) // Pass through other git add options
   .action(addCommand);
 
-// Commit command
 program
   .command('commit')
   .description('Generate AI-powered commit message based on staged changes')
@@ -45,13 +52,6 @@ program
   .allowUnknownOption(true) // Pass through other git commit options
   .action(commitCommand);
 
-// Model command
-program
-  .command('model [model-id]')
-  .description('Change the AI model used for generating commit messages')
-  .action(modelCommand);
-
-// Pull request command
 program
   .command('pr create')
   .description('Create a pull request with AI-generated title and description')
@@ -61,7 +61,30 @@ program
   .option('-B, --base <branch>', 'Base branch to create PR against')
   .option('-e, --edit', 'Edit PR details before submission', true)
   .option('--no-edit', 'Skip editing PR details')
+  .allowUnknownOption(true)
   .action(prCreateCommand);
+
+// Default command handler for all other git commands
+program
+  .command('*', { hidden: true }) // Catch-all command that won't show in help
+  .allowUnknownOption(true)
+  .action((cmd, options) => {
+    if (!isGitRepository()) {
+      console.error(chalk.red('Error: Not a git repository'));
+      process.exit(1);
+    }
+    
+    try {
+      // Get all arguments passed to the original command
+      const args = process.argv.slice(2);
+      
+      // Execute git with all arguments
+      execSync(`git ${args.join(' ')}`, { stdio: 'inherit' });
+    } catch (error) {
+      // Git will handle its own error output through stdio: 'inherit'
+      process.exit(1);
+    }
+  });
 
 // Main logic
 async function main() {


### PR DESCRIPTION
## Summary
This PR introduces a catch-all command in GitPT to proxy any unrecognized git commands, making GitPT act as a complete git wrapper.

## Changes
- Refactor command handling to replace the catch-all command with an event handler for unknown commands
- Add a catch-all command in the CLI to forward unrecognized git commands to git
- Update README to reflect GitPT's capability as a full git wrapper

## How to test
1. Use GitPT to run a recognized git command (e.g., `gitpt status`)
2. Use GitPT to run an unrecognized git command (e.g., `gitpt somecustomcommand`)
3. Verify that unrecognized commands are correctly proxied to git and behave as expected
