### PR TITLE
feat(pr): use GitHub PR template when generating PR details

### DIFF
--- a/src/commands/pr/context/systemPrompt.ts
+++ b/src/commands/pr/context/systemPrompt.ts
@@ -15,4 +15,8 @@ For the description:
 
 Format the description in Markdown with sections.
 Do not include "PR" or "Pull Request" in the title.
+
+If the user provides a pull request template, follow its structure for the
+description instead of the default sections above: keep its headings, ordering,
+and checklists, and fill them in from the changes.
 `;

--- a/src/commands/pr/context/userPrompt.ts
+++ b/src/commands/pr/context/userPrompt.ts
@@ -1,11 +1,34 @@
-export const userPrompt = (context: string) => `
-Generate a pull request title and description for the following changes:
+export const userPrompt = (context: string, template?: string) => {
+  const intro = `Generate a pull request title and description for the following changes:
 
-${context}
+${context}`;
+
+  if (template) {
+    return `${intro}
+
+This repository provides the pull request description template below. Use it to structure the description:
+- Keep its section headings, ordering, and any checklists or tables intact.
+- Fill each section in based on the changes above.
+- Remove HTML comments (\`<!-- ... -->\`) — they are author instructions, not content.
+- For checklists, tick (\`[x]\`) items the changes satisfy and leave the rest unchecked.
+- Omit a section only if it clearly does not apply.
+
+--- PR TEMPLATE START ---
+${template}
+--- PR TEMPLATE END ---
+
+Format your response exactly like this:
+Title: <concise title following the title rules>
+Description:
+<the filled-in template, in Markdown>
+`;
+  }
+
+  return `${intro}
 
 Format your response exactly like this example:
 Title: Add user authentication with JWT
-Description: 
+Description:
 ## Summary
 This PR adds user authentication using JWT tokens.
 
@@ -20,3 +43,4 @@ This PR adds user authentication using JWT tokens.
 2. Login with the new user credentials
 3. Use the returned token to access protected endpoints
 `;
+};

--- a/src/commands/pr/generatePRDetails.ts
+++ b/src/commands/pr/generatePRDetails.ts
@@ -4,6 +4,7 @@ import { getLLMClient } from "../../llm/index.js";
 import { systemPrompt } from "./context/systemPrompt.js";
 import { userPrompt } from "./context/userPrompt.js";
 import { getPRContext } from "./getPRContext.js";
+import { getPRTemplate } from "./getPRTemplate.js";
 
 export const generatePRDetails = async (): Promise<{
   title: string;
@@ -12,7 +13,8 @@ export const generatePRDetails = async (): Promise<{
   const { model } = getConfig();
 
   const context = getPRContext().join("\n\n");
-  const userPromptWithContext = userPrompt(context);
+  const template = getPRTemplate();
+  const userPromptWithContext = userPrompt(context, template ?? undefined);
 
   const llmClient = getLLMClient();
 

--- a/src/commands/pr/getPRTemplate.ts
+++ b/src/commands/pr/getPRTemplate.ts
@@ -1,0 +1,45 @@
+import chalk from "chalk";
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join, relative } from "path";
+import { git } from "../../services/git/index.js";
+
+const TEMPLATE_DIRS = ["", ".github", "docs"];
+const TEMPLATE_FILE_PATTERN = /^pull_request_template(\.md|\.markdown|\.txt)?$/i;
+
+export const getPRTemplate = (): string | null => {
+  const root = git.getRepositoryRoot();
+
+  for (const dir of TEMPLATE_DIRS) {
+    const base = dir ? join(root, dir) : root;
+
+    let entries: string[];
+    try {
+      entries = readdirSync(base);
+    } catch (error) {
+      continue;
+    }
+
+    const match = entries.find((entry) => TEMPLATE_FILE_PATTERN.test(entry));
+    if (!match) {
+      continue;
+    }
+
+    const filePath = join(base, match);
+    try {
+      if (!statSync(filePath).isFile()) {
+        continue;
+      }
+      const content = readFileSync(filePath, "utf-8").trim();
+      if (content) {
+        console.log(
+          chalk.blue(`Using PR template: ${relative(root, filePath)}`)
+        );
+        return content;
+      }
+    } catch (error) {
+      continue;
+    }
+  }
+
+  return null;
+};

--- a/src/services/git/getRepositoryRoot.ts
+++ b/src/services/git/getRepositoryRoot.ts
@@ -1,0 +1,9 @@
+import { execSync } from "child_process";
+
+export const getRepositoryRoot = (): string => {
+  try {
+    return execSync("git rev-parse --show-toplevel").toString().trim();
+  } catch (error) {
+    return process.cwd();
+  }
+};

--- a/src/services/git/index.ts
+++ b/src/services/git/index.ts
@@ -4,6 +4,7 @@ import { getChangedFiles } from "./getChangedFiles.js";
 import { getCommitsSinceBaseBranch } from "./getCommitsSinceBaseBranch.js";
 import { getCurrentBranch } from "./getCurrentBranch.js";
 import { getDefaultBranch } from "./getDefaultBranch.js";
+import { getRepositoryRoot } from "./getRepositoryRoot.js";
 import { getStagedChanges } from "./getStagedChanges.js";
 import { getStagedFiles } from "./getStagedFiles.js";
 import { hasStagedChanges } from "./hasStagedChanges.js";
@@ -17,6 +18,7 @@ export const git = {
   getCommitsSinceBaseBranch,
   getCurrentBranch,
   getDefaultBranch,
+  getRepositoryRoot,
   hasStagedChanges,
   getStagedChanges,
   getStagedFiles,


### PR DESCRIPTION
`gitpt pr create` now uses the repository's GitHub pull request template when one exists (searched in the repo root, `.github/`, then `docs/`), filling in its sections instead of a fixed default. Behavior is unchanged when no template is found.

Closes #19.