### PR TITLE
fix(commit): budget commitlint rules and retry errors when fitting context

### DIFF
--- a/src/commands/commit/generateCommitMessage.ts
+++ b/src/commands/commit/generateCommitMessage.ts
@@ -9,10 +9,9 @@ import { userPrompt } from "./context/userPrompt.js";
 
 export const generateCommitMessage = async (
   diff: string,
-  validationErrors?: string
+  validationErrors?: string,
+  precomputedBaseRules?: string
 ): Promise<string> => {
-  // Check if commitlint is configured
-  const hasCommitlint = hasCommitlintConfig();
   const config = getConfig();
 
   // Check if we have a configured model
@@ -24,7 +23,9 @@ export const generateCommitMessage = async (
 
   const { model } = config;
 
-  const baseRules = hasCommitlint ? getCommitlintRules() : "";
+  const baseRules =
+    precomputedBaseRules ??
+    (hasCommitlintConfig() ? getCommitlintRules() : "");
 
   const errorInfo = validationErrors
     ? `\n\nYOUR PREVIOUS MESSAGE FAILED VALIDATION WITH THESE ERRORS:\n${validationErrors}\n\nFIX THESE ISSUES IN YOUR NEW MESSAGE.`

--- a/src/commands/commit/index.ts
+++ b/src/commands/commit/index.ts
@@ -3,13 +3,17 @@ import inquirer from "inquirer";
 import { capabilitiesMiddleware } from "../middleware/capabilitiesMiddleware/index.js";
 import { setupMiddleware } from "../middleware/setupMiddleware/index.js";
 import { git } from "../../services/git/index.js";
+import { countTokens } from "../../llm/tokenCount.js";
 import {
+  getCommitlintRules,
   hasCommitlintConfig,
   validateCommitMessage,
 } from "../../utils/commitlint.js";
 import { hasStagedChangesMiddleware } from "../middleware/hasStagedChangesMiddleware.js";
 import { generateCommitMessage } from "./generateCommitMessage.js";
 import { prepareCommitContext } from "./summarizeDiff.js";
+
+const RESERVED_VALIDATION_RETRY_TOKENS = 256;
 
 interface CommitOptions {
   message?: string;
@@ -32,21 +36,9 @@ export const commitCommand = async (options: CommitOptions): Promise<void> => {
       // Get staged changes
       const diff = git.getStagedChanges();
 
-      const context = await prepareCommitContext(diff);
-
-      console.log(chalk.blue("Generating commit message..."));
-
-      // Check if commitlint is configured
       let hasCommitlint = false;
       try {
         hasCommitlint = hasCommitlintConfig();
-        if (hasCommitlint) {
-          console.log(
-            chalk.blue(
-              "Commitlint configuration detected. Generating message according to rules..."
-            )
-          );
-        }
       } catch (error) {
         console.warn(
           chalk.yellow(
@@ -55,8 +47,24 @@ export const commitCommand = async (options: CommitOptions): Promise<void> => {
         );
       }
 
+      const baseRules = hasCommitlint ? getCommitlintRules() : "";
+      const reservedPromptTokens =
+        countTokens(baseRules) + RESERVED_VALIDATION_RETRY_TOKENS;
+
+      const context = await prepareCommitContext(diff, reservedPromptTokens);
+
+      console.log(chalk.blue("Generating commit message..."));
+
+      if (hasCommitlint) {
+        console.log(
+          chalk.blue(
+            "Commitlint configuration detected. Generating message according to rules..."
+          )
+        );
+      }
+
       // Generate first commit message
-      commitMessage = await generateCommitMessage(context);
+      commitMessage = await generateCommitMessage(context, undefined, baseRules);
 
       // If commitlint is configured, try to validate and regenerate up to 3 times
       if (hasCommitlint) {
@@ -100,7 +108,8 @@ export const commitCommand = async (options: CommitOptions): Promise<void> => {
                 try {
                   commitMessage = await generateCommitMessage(
                     context,
-                    validationErrors
+                    validationErrors,
+                    baseRules
                   );
                 } catch (error) {
                   console.warn(

--- a/src/commands/commit/summarizeDiff.ts
+++ b/src/commands/commit/summarizeDiff.ts
@@ -144,11 +144,17 @@ const summarizeChunk = async (content: string): Promise<string> => {
   return response.choices[0].message.content?.trim() || "";
 };
 
-export const prepareCommitContext = async (diff: string): Promise<string> => {
+export const prepareCommitContext = async (
+  diff: string,
+  reservedPromptTokens = 0
+): Promise<string> => {
   const window = getContextWindow();
   if (!Number.isFinite(window)) return diff;
 
-  const fitBudget = Math.floor((window - RESERVED_OUTPUT_TOKENS) * MARGIN);
+  const fitBudget = Math.max(
+    0,
+    Math.floor((window - RESERVED_OUTPUT_TOKENS - reservedPromptTokens) * MARGIN)
+  );
   if (finalPromptTokens(diff) <= fitBudget) return diff;
 
   const spinner = ora({ text: "Analyzing diff size..." }).start();


### PR DESCRIPTION
`prepareCommitContext` sized the summarized context against `systemPrompt` + `userPrompt` only, but `generateCommitMessage` also sends the commitlint rules and (on validation retries) the error feedback — so a verbose commitlint config or large retry error could push the real prompt past the model window even after summarization. This reserves that overhead up front: the commitlint rules are computed once, a token allowance is passed into `prepareCommitContext`, and the rules are reused when generating so the budget matches what's actually sent.

Closes #23.