### PR TITLE
perf(commit): memoize token counts to cut fm spawns

### DIFF
--- a/src/llm/tokenCount.ts
+++ b/src/llm/tokenCount.ts
@@ -3,9 +3,7 @@ import { getConfig } from "../config.js";
 
 const estimateTokens = (text: string): number => Math.ceil(text.length / 4);
 
-export const countTokens = (text: string): number => {
-  const { provider } = getConfig();
-
+const countTokensUncached = (text: string, provider?: string): number => {
   if (provider === "apple") {
     const result = spawnSync("fm", ["token-count", "-q"], {
       input: text,
@@ -18,6 +16,20 @@ export const countTokens = (text: string): number => {
   }
 
   return estimateTokens(text);
+};
+
+const cache = new Map<string, number>();
+
+export const countTokens = (text: string): number => {
+  const { provider } = getConfig();
+  const key = `${provider ?? ""}:${text}`;
+
+  const cached = cache.get(key);
+  if (cached !== undefined) return cached;
+
+  const tokens = countTokensUncached(text, provider);
+  cache.set(key, tokens);
+  return tokens;
 };
 
 export const getContextWindow = (): number => {


### PR DESCRIPTION
`countTokens` shells out to `fm token-count` via `spawnSync` on every call, and the diff summarizer counts the same strings repeatedly (prompt overheads, the reduce-loop's recount of the framed summary, the truncation halving loops). This memoizes results by provider + text, so identical inputs are counted once per process. Verified with a shimmed `fm`: 8 calls across 3 unique strings produced exactly 3 spawns.

Addresses the memoization lever in #25.