### PR TITLE
fix(commit): tell the model how to read added vs removed diff lines

### DIFF
--- a/src/commands/commit/context/systemPrompt.ts
+++ b/src/commands/commit/context/systemPrompt.ts
@@ -15,6 +15,12 @@ Critical Rules:
 - Do NOT include a detailed message body section, just the commit title line
 - Do NOT use multiple lines, even for a single message
 
+Reading the diff (IMPORTANT):
+- The user message is a unified git diff.
+- Lines starting with "+" were ADDED; lines starting with "-" were REMOVED. Lines with no prefix are unchanged context.
+- Describe what actually happened: use "remove"/"delete" for removed lines, "add" for added lines, and "update"/"change" when lines were both removed and added.
+- Never describe a removed line as if it were added (or vice versa).
+
 Examples of Good Commit Messages:
 - feat: add user authentication system
 - fix: resolve crash when opening settings menu


### PR DESCRIPTION
Weaker local models often describe a removed line as if it were added. This adds explicit unified-diff guidance to the commit system prompt. `+` lines are additions, `-` lines are removals, and removals must be described as removals.

This also needs to be tested (easily testable with Apple Foundation Models CLI tool `fm`)

Closes #18.

Note: this is a prompt-only change. The wording compiles and reads correctly, but confirming it actually shifts behavior on a weak local model needs a local LLM, which isn't available in this environment.