### PR TITLE
feat: default model

### DIFF
--- a/src/commands/middleware/setupMiddleware/index.ts
+++ b/src/commands/middleware/setupMiddleware/index.ts
@@ -1,12 +1,15 @@
 import chalk from "chalk";
 import inquirer from "inquirer";
 import {
+  clearAcceptedDefault,
+  getAcceptedDefault,
   getConfig,
   GitPTConfig,
   saveConfig,
+  setAcceptedDefault,
   validateConfig,
 } from "../../../config.js";
-import { resolveDefaultModel } from "./defaultModels.js";
+import { DefaultModel, resolveDefaultModel } from "./defaultModels.js";
 import {
   isAppleFoundationModelsSupported,
   setupApple,
@@ -22,26 +25,67 @@ export const setupMiddleware = async (options?: {
   // Always get the current config, even if it's empty
   const existingConfig = getConfig();
 
-  // If we're running a command, and the config is valid, continue with the command
+  const defaultModel = resolveDefaultModel();
+  const acceptedDefault = getAcceptedDefault();
+  const interactive = Boolean(process.stdin.isTTY);
+
+  const applyDefault = (model: DefaultModel): GitPTConfig => {
+    saveConfig(model.config);
+    setAcceptedDefault(model.id);
+    return getConfig();
+  };
+
+  const confirmDefault = async (message: string): Promise<boolean> => {
+    const { useDefault } = await inquirer.prompt([
+      { type: "confirm", name: "useDefault", message, default: true },
+    ]);
+    return useDefault;
+  };
+
   if (context === "command") {
-    const isValidConfig = validateConfig();
-    if (isValidConfig.isValid) {
+    if (validateConfig().isValid) {
+      if (!acceptedDefault) return getConfig();
+      if (!defaultModel || defaultModel.id === acceptedDefault) {
+        return getConfig();
+      }
+      if (
+        !interactive ||
+        (await confirmDefault(
+          `The recommended default changed to ${defaultModel.label}. Use it?`
+        ))
+      ) {
+        const result = applyDefault(defaultModel);
+        if (interactive) {
+          console.log(chalk.green(`✓ Now using ${defaultModel.label}.`));
+        }
+        return result;
+      }
       return getConfig();
     }
 
-    if (!existingConfig.provider) {
-      const defaultModel = resolveDefaultModel();
-      if (defaultModel) {
-        saveConfig(defaultModel.config);
+    if (!existingConfig.provider && defaultModel) {
+      if (!interactive) return applyDefault(defaultModel);
+      if (
+        await confirmDefault(
+          `No model configured. Use ${defaultModel.label} by default?`
+        )
+      ) {
+        const result = applyDefault(defaultModel);
         console.log(
-          chalk.gray(
-            `No model configured; using ${defaultModel.label} by default. Run 'gitpt model' to change.`
+          chalk.green(
+            `✓ Using ${defaultModel.label}. Run 'gitpt model' to change.`
           )
         );
-        return getConfig();
+        return result;
       }
+    } else if (!interactive) {
+      throw new Error(
+        "GitPT is not configured. Run 'gitpt setup' in an interactive terminal."
+      );
     }
   }
+
+  clearAcceptedDefault();
 
   // For initial setup or model command, start by selecting the provider
   const providerChoices: Array<{

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -1,0 +1,38 @@
+import chalk from "chalk";
+import inquirer from "inquirer";
+import { clearConfig, getConfig } from "../config.js";
+
+export const resetCommand = async (
+  options: { yes?: boolean } = {}
+): Promise<void> => {
+  const hasConfig = Object.values(getConfig()).some(
+    (value) => value !== undefined
+  );
+
+  if (!hasConfig) {
+    console.log(chalk.gray("GitPT has no saved configuration to reset."));
+    return;
+  }
+
+  if (!options.yes) {
+    const { confirm } = await inquirer.prompt([
+      {
+        type: "confirm",
+        name: "confirm",
+        message:
+          "Reset GitPT? This clears the saved provider, model, and API key.",
+        default: false,
+      },
+    ]);
+
+    if (!confirm) {
+      console.log(chalk.gray("Reset cancelled."));
+      return;
+    }
+  }
+
+  clearConfig();
+  console.log(
+    chalk.green("✓ GitPT configuration reset. Run 'gitpt setup' to reconfigure.")
+  );
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -76,3 +76,21 @@ export const validateConfig = (): { isValid: boolean; errors?: string[] } => {
 export const clearConfig = (): void => {
   config.clear();
 };
+
+const ACCEPTED_DEFAULT_KEY = "acceptedDefault";
+
+export const getAcceptedDefault = (): string | undefined => {
+  try {
+    return config.get(ACCEPTED_DEFAULT_KEY);
+  } catch {
+    return undefined;
+  }
+};
+
+export const setAcceptedDefault = (id: string): void => {
+  config.set(ACCEPTED_DEFAULT_KEY, id);
+};
+
+export const clearAcceptedDefault = (): void => {
+  config.delete(ACCEPTED_DEFAULT_KEY);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { commitCommand } from "./commands/commit/index.js";
 import { configCommand } from "./commands/config.js";
 import { modelCommand } from "./commands/model.js";
 import { prCreateCommand } from "./commands/pr/index.js";
+import { resetCommand } from "./commands/reset.js";
 import { setupCommand } from "./commands/setup.js";
 
 const program = new Command();
@@ -34,6 +35,12 @@ program
   .command("model")
   .description("Change the AI model used for generating commit messages")
   .action(modelCommand);
+
+program
+  .command("reset")
+  .description("Reset GitPT configuration (clears provider, model, and API key)")
+  .option("-y, --yes", "Skip the confirmation prompt")
+  .action(resetCommand);
 
 // Enhanced git commands
 program


### PR DESCRIPTION
Adding default model for users who have a model already available.

First pilot model being Apple Foundation Model CLI tool `fm` available since macOS 27.