### PR TITLE
feat: allow non-interactive setup via command options

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -1,10 +1,64 @@
 import chalk from "chalk";
-import { clearConfig } from "../config.js";
+import { clearConfig, saveConfig, type GitPTConfig } from "../config.js";
+import { getApiKey, saveApiKey } from "../llm/providers/apiKey.js";
+import { getProviderClass } from "../llm/registry.js";
 import { setupMiddleware } from "./middleware/setupMiddleware/index.js";
 
+interface SetupOptions {
+  clearConfig?: boolean;
+  provider?: string;
+  model?: string;
+  endpoint?: string;
+  apiKey?: string;
+}
+
+// Print an error and exit non-zero. Returns `never`, so TypeScript knows the
+// code after a fail() call is unreachable (lets us narrow `spec` below).
+const fail = (message: string): never => {
+  console.error(chalk.red(`Error: ${message}`));
+  process.exit(1);
+};
+
+// Non-interactive setup: configure straight from flags, no prompts.
+const headlessSetup = (options: SetupOptions): void => {
+  const spec = getProviderClass(options.provider);
+  if (!spec) {
+    return fail(
+      `Unknown provider "${options.provider}". Valid: local, openrouter, openai, anthropic, apple.`,
+    );
+  }
+  if (!options.model) {
+    fail("--model is required.");
+  }
+  if (spec.requiresEndpoint && !options.endpoint) {
+    fail(`Provider "${spec.id}" requires --endpoint.`);
+  }
+  if (spec.requiresApiKey && !options.apiKey && !getApiKey()) {
+    fail(`Provider "${spec.id}" requires --api-key.`);
+  }
+
+  const config: GitPTConfig = {
+    provider: spec.id as GitPTConfig["provider"],
+    model: options.model,
+  };
+  if (options.endpoint) config.customLLMEndpoint = options.endpoint;
+  saveConfig(config);
+  if (options.apiKey) saveApiKey(spec.id, options.apiKey);
+
+  console.log(
+    chalk.green(`✓ Configured ${spec.label} with model ${options.model}.`),
+  );
+};
+
 export const setupCommand = async (
-  options: { clearConfig?: boolean } = {},
+  options: SetupOptions = {},
 ): Promise<void> => {
+  // Flags present → headless path, skip the interactive prompts.
+  if (options.provider) {
+    headlessSetup(options);
+    return;
+  }
+
   console.log(chalk.blue("GitPT Setup"));
   console.log(
     "This will configure GitPT to use an LLM for generating commit messages.",

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,10 @@ program
   .description(
     "Configure GitPT with your OpenRouter API key and model selection"
   )
+  .option("--provider <id>", "Provider id (local, openrouter, openai, anthropic, apple)")
+  .option("--model <id>", "Model id")
+  .option("--endpoint <url>", "Custom LLM endpoint (for local)")
+  .option("--api-key <key>", "API key (for providers that need one)")
   .action(setupCommand);
 
 program


### PR DESCRIPTION
filipbarta@macbook-server GitPT % npm run build

> gitpt@1.6.1 build
> tsc

filipbarta@macbook-server GitPT %  gitpt config
GitPT Configuration
{
  apiKey: undefined,
  provider: 'local',
  customLLMEndpoint: 'http://127.0.0.1:1234',
  model: 'google/gemma-4-e4b',
  apiKeys: undefined,
  contextWindow: 8192
}
filipbarta@macbook-server GitPT %   gitpt setup --provider local --model google/gemma-4-e4b --endpoint http://127.0.0.1:1234
✓ Configured Local LLM with model google/gemma-4-e4b.
filipbarta@macbook-server GitPT % gitpt setup --provider bogus --model x; echo $?
Error: Unknown provider "bogus". Valid: local, openrouter, openai, anthropic, apple.
1
filipbarta@macbook-server GitPT % gitpt add .
filipbarta@macbook-server GitPT % gitpt commit --no-edit
Generating commit message...
Commitlint configuration detected. Generating message according to rules...
Validating commit message against commitlint rules...
✓ Commit message passed validation
✓ Commit message generated

Generated message:
feat: allow non-interactive setup via command options

[feat/headless-model-config 769860d] feat: allow non-interactive setup via command options
 2 files changed, 60 insertions(+), 2 deletions(-)
✓ Changes committed successfully
filipbarta@macbook-server GitPT %  git push -u origin feat/headless-model-config
Enumerating objects: 11, done.
Counting objects: 100% (11/11), done.
Delta compression using up to 10 threads
Compressing objects: 100% (6/6), done.
Writing objects: 100% (6/6), 1.59 KiB | 1.59 MiB/s, done.
Total 6 (delta 4), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (4/4), completed with 4 local objects.
remote: 
remote: Create a pull request for 'feat/headless-model-config' on GitHub by visiting:
remote:      https://github.com/bartaxyz/GitPT/pull/new/feat/headless-model-config
remote: 
To https://github.com/bartaxyz/GitPT
 * [new branch]      feat/headless-model-config -> feat/headless-model-config
branch 'feat/headless-model-config' set up to track 'origin/feat/headless-model-config'.
filipbarta@macbook-server GitPT % 
