### PR TITLE
fix: clear stale context window when switching providers

### DIFF
--- a/src/commands/middleware/setupMiddleware/index.ts
+++ b/src/commands/middleware/setupMiddleware/index.ts
@@ -7,6 +7,7 @@ import {
   GitPTConfig,
   saveConfig,
   setAcceptedDefault,
+  unsetConfigKey,
 } from "../../../config.js";
 import {
   getProviderClass,
@@ -106,6 +107,13 @@ export const setupMiddleware = async (options?: {
   existingConfig.provider = providerAnswer.provider as NonNullable<
     GitPTConfig["provider"]
   >;
+
+  // Only the local provider manages a context window. Clear any stale value
+  // carried over from a previous provider when switching to another one.
+  if (existingConfig.provider !== "local") {
+    delete existingConfig.contextWindow;
+    unsetConfigKey("contextWindow");
+  }
 
   const spec = getProviderClass(existingConfig.provider);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -61,6 +61,10 @@ export const saveConfig = (newConfig: GitPTConfig): void => {
   }
 };
 
+export const unsetConfigKey = (key: keyof GitPTConfig): void => {
+  config.delete(key);
+};
+
 export const clearConfig = (): void => {
   config.clear();
 };


### PR DESCRIPTION
Switching away from the local provider (e.g. LM Studio) left its `contextWindow` value in the config. Only the local provider manages a context window, so the stale value was shown for providers like Apple where it does not apply.

Now clears `contextWindow` from config when the selected provider is not local.