### PR TITLE
fix: pass git flags through to git commit (EDITORS-85)

### DIFF
--- a/src/commands/commit/index.ts
+++ b/src/commands/commit/index.ts
@@ -12,19 +12,37 @@ import { generateCommitMessage } from "./generateCommitMessage.js";
 import { prepareCommitContext } from "./summarizeDiff.js";
 
 interface CommitOptions {
-    message?: string;
-    edit?: boolean;
-    dryRun?: boolean;
+  message?: string;
+  edit?: boolean;
+  dryRun?: boolean;
+  [key: string]: any;
+}
+
+interface Command {
+  parent?: Command;
+  args?: {
+    allowEmpty: boolean;
     [key: string]: any;
-  }
+  };
+}
 
 export const commitCommand = async (
   options: CommitOptions,
-  command?: { args?: string[] },
+  command?: Command,
 ): Promise<void> => {
   capabilitiesMiddleware(["git"]);
   await setupMiddleware();
-  hasStagedChangesMiddleware();
+
+  // TODO: Please introduce a separate function, or dive deeper into documentation
+  // about how this works. This is just a quick attempt to make this work, it won't be final
+  const args =
+    (!command?.args || command.args.length === 0
+      ? command?.parent?.args
+      : command?.args) || [];
+
+  if (!args.includes("--allow-empty")) {
+    hasStagedChangesMiddleware();
+  }
 
   let commitMessage: string;
   let context: string | undefined;
@@ -48,15 +66,15 @@ export const commitCommand = async (
         if (hasCommitlint) {
           console.log(
             chalk.blue(
-              "Commitlint configuration detected. Generating message according to rules..."
-            )
+              "Commitlint configuration detected. Generating message according to rules...",
+            ),
           );
         }
       } catch (error) {
         console.warn(
           chalk.yellow(
-            "Warning: Error detecting commitlint config, proceeding without commitlint validation."
-          )
+            "Warning: Error detecting commitlint config, proceeding without commitlint validation.",
+          ),
         );
       }
 
@@ -67,7 +85,7 @@ export const commitCommand = async (
       if (hasCommitlint) {
         try {
           console.log(
-            chalk.blue("Validating commit message against commitlint rules...")
+            chalk.blue("Validating commit message against commitlint rules..."),
           );
 
           // Try up to 3 times to get a valid message
@@ -91,8 +109,8 @@ export const commitCommand = async (
                     attempts < MAX_ATTEMPTS
                       ? "Regenerating..."
                       : "Max attempts reached."
-                  }`
-                )
+                  }`,
+                ),
               );
 
               if (validation.errors) {
@@ -105,13 +123,13 @@ export const commitCommand = async (
                 try {
                   commitMessage = await generateCommitMessage(
                     context,
-                    validationErrors
+                    validationErrors,
                   );
                 } catch (error) {
                   console.warn(
                     chalk.yellow(
-                      "Error regenerating message, breaking validation loop."
-                    )
+                      "Error regenerating message, breaking validation loop.",
+                    ),
                   );
                   break;
                 }
@@ -136,14 +154,14 @@ export const commitCommand = async (
 
                 if (action === "abort") {
                   console.log(
-                    chalk.red("Commit aborted due to validation failures.")
+                    chalk.red("Commit aborted due to validation failures."),
                   );
                   process.exit(1);
                 } else if (action === "edit") {
                   options.edit = true; // Force editor to open
                 } else {
                   console.log(
-                    chalk.yellow("Proceeding with invalid message...")
+                    chalk.yellow("Proceeding with invalid message..."),
                   );
                 }
                 break;
@@ -154,13 +172,13 @@ export const commitCommand = async (
           // If there's an error with commitlint validation, continue without it
           console.warn(
             chalk.yellow(
-              "Warning: Error during commitlint validation, proceeding without validation."
-            )
+              "Warning: Error during commitlint validation, proceeding without validation.",
+            ),
           );
           console.warn(
             chalk.gray(
-              "This may be due to an ESM module cycle conflict or missing commitlint dependencies."
-            )
+              "This may be due to an ESM module cycle conflict or missing commitlint dependencies.",
+            ),
           );
         }
       }
@@ -173,7 +191,7 @@ export const commitCommand = async (
     } catch (error) {
       console.error(
         chalk.red("Error:"),
-        error instanceof Error ? error.message : String(error)
+        error instanceof Error ? error.message : String(error),
       );
       process.exit(1);
     }
@@ -238,27 +256,31 @@ export const commitCommand = async (
         const validation = await validateCommitMessage(commitMessage);
         if (!validation.valid) {
           console.log(
-            chalk.yellow("Warning: the commit message has validation issues."),
+            chalk.yellow(
+              "Warning: Edited message still has validation issues.",
+            ),
           );
           if (validation.errors) console.log(chalk.gray(validation.errors));
         }
       }
-    } catch {
-      // Never block the commit on a validation hiccup.
+    } catch (error) {
+      // If validation fails, just warn and continue
+      console.warn(
+        chalk.yellow("Could not validate edited message, proceeding anyway."),
+      );
     }
   }
 
-  // Forward any unknown flags (e.g. --allow-empty, --amend) straight to git.
-  // Commander collects those in command.args, not in the typed `options`.
-  const passthroughArgs = command?.args ?? [];
-
   try {
-    git.commit(commitMessage, passthroughArgs);
+    // @ts-ignore
+    // TODO: Fix the args here. Because implicitly, the args also pass the initial command,
+    // so if they're passed altogether, git will get additional `commit`
+    git.commit(commitMessage, args);
     console.log(chalk.green("✓ Changes committed successfully"));
   } catch (error) {
     console.error(
       chalk.red("Error:"),
-      error instanceof Error ? error.message : String(error)
+      error instanceof Error ? error.message : String(error),
     );
     process.exit(1);
   }

--- a/src/commands/commit/index.ts
+++ b/src/commands/commit/index.ts
@@ -18,7 +18,10 @@ interface CommitOptions {
     [key: string]: any;
   }
 
-export const commitCommand = async (options: CommitOptions): Promise<void> => {
+export const commitCommand = async (
+  options: CommitOptions,
+  command?: { args?: string[] },
+): Promise<void> => {
   capabilitiesMiddleware(["git"]);
   await setupMiddleware();
   hasStagedChangesMiddleware();
@@ -245,18 +248,12 @@ export const commitCommand = async (options: CommitOptions): Promise<void> => {
     }
   }
 
-  // Extract other git options to pass through
-  const gitOptions = Object.keys(options)
-    .filter((key) => !["message", "edit"].includes(key))
-    .map((key) => {
-      if (typeof options[key] === "boolean") {
-        return options[key] ? `--${key}` : `--no-${key}`;
-      }
-      return `--${key}=${options[key]}`;
-    });
+  // Forward any unknown flags (e.g. --allow-empty, --amend) straight to git.
+  // Commander collects those in command.args, not in the typed `options`.
+  const passthroughArgs = command?.args ?? [];
 
   try {
-    git.commit(commitMessage, gitOptions);
+    git.commit(commitMessage, passthroughArgs);
     console.log(chalk.green("✓ Changes committed successfully"));
   } catch (error) {
     console.error(

--- a/src/commands/commit/index.ts
+++ b/src/commands/commit/index.ts
@@ -10,6 +10,8 @@ import {
 import { hasStagedChangesMiddleware } from "../middleware/hasStagedChangesMiddleware.js";
 import { generateCommitMessage } from "./generateCommitMessage.js";
 import { prepareCommitContext } from "./summarizeDiff.js";
+import type { Command } from "commander";
+import { passthroughArgs } from "../passthroughArgs.js";
 
 interface CommitOptions {
   message?: string;
@@ -18,28 +20,17 @@ interface CommitOptions {
   [key: string]: any;
 }
 
-interface Command {
-  parent?: Command;
-  args?: {
-    allowEmpty: boolean;
-    [key: string]: any;
-  };
-}
-
 export const commitCommand = async (
   options: CommitOptions,
-  command?: Command,
+  command: Command,
 ): Promise<void> => {
   capabilitiesMiddleware(["git"]);
   await setupMiddleware();
 
-  // TODO: Please introduce a separate function, or dive deeper into documentation
-  // about how this works. This is just a quick attempt to make this work, it won't be final
-  const args =
-    (!command?.args || command.args.length === 0
-      ? command?.parent?.args
-      : command?.args) || [];
+  // Git flags the user passed through (e.g. --allow-empty), forwarded to git.
+  const args = passthroughArgs(command);
 
+  // --allow-empty is valid even with nothing staged.
   if (!args.includes("--allow-empty")) {
     hasStagedChangesMiddleware();
   }
@@ -272,9 +263,6 @@ export const commitCommand = async (
   }
 
   try {
-    // @ts-ignore
-    // TODO: Fix the args here. Because implicitly, the args also pass the initial command,
-    // so if they're passed altogether, git will get additional `commit`
     git.commit(commitMessage, args);
     console.log(chalk.green("✓ Changes committed successfully"));
   } catch (error) {

--- a/src/commands/passthroughArgs.ts
+++ b/src/commands/passthroughArgs.ts
@@ -1,0 +1,11 @@
+import type { Command } from "commander";
+
+/**
+ * Extra tokens the user passed to a GitPT command that aren't GitPT's own
+ * options (e.g. --allow-empty, --amend) — to forward to the wrapped git command.
+ * Commander leaves these in `command.args`; we drop the command's own name in
+ * case it leaks in. Shared so every command forwards passthrough flags the same
+ * way.
+ */
+export const passthroughArgs = (command: Command): string[] =>
+  (command.args ?? []).filter((arg) => arg !== command.name());

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ program
 program
   .command("setup")
   .description(
-    "Configure GitPT with your OpenRouter API key and model selection"
+    "Configure GitPT with your OpenRouter API key and model selection",
   )
   .option("--provider <id>", "Provider id (local, openrouter, openai, anthropic, apple)")
   .option("--model <id>", "Model id")
@@ -32,7 +32,9 @@ program
 
 program
   .command("config")
-  .description("Configure GitPT with your OpenRouter API key and model selection")
+  .description(
+    "Configure GitPT with your OpenRouter API key and model selection",
+  )
   .action(configCommand);
 
 program
@@ -42,7 +44,9 @@ program
 
 program
   .command("reset")
-  .description("Reset GitPT configuration (clears provider, model, and API key)")
+  .description(
+    "Reset GitPT configuration (clears provider, model, and API key)",
+  )
   .option("-y, --yes", "Skip the confirmation prompt")
   .action(resetCommand);
 
@@ -52,11 +56,12 @@ program
   .description("Generate AI-powered commit message based on staged changes")
   .option(
     "-m, --message <message>",
-    "use provided message instead of generating one"
+    "use provided message instead of generating one",
   )
   .option("-e, --edit", "edit the message after generation")
   .option("--no-edit", "do not edit the message after generation")
   .option("--dry-run", "generate and print the message but do not commit")
+  .option("--allow-empty")
   .allowUnknownOption(true) // Pass through other git commit options
   .allowExcessArguments(true) // ...including bare flags like --allow-empty
   .action(commitCommand);
@@ -93,7 +98,7 @@ async function main() {
   } catch (error) {
     console.error(
       chalk.red("Error:"),
-      error instanceof Error ? error.message : String(error)
+      error instanceof Error ? error.message : String(error),
     );
     process.exit(1);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ program
   .option("--no-edit", "do not edit the message after generation")
   .option("--dry-run", "generate and print the message but do not commit")
   .allowUnknownOption(true) // Pass through other git commit options
+  .allowExcessArguments(true) // ...including bare flags like --allow-empty
   .action(commitCommand);
 
 program
@@ -70,6 +71,7 @@ program
   .option("-e, --edit", "Edit PR details before submission", true)
   .option("--no-edit", "Skip editing PR details")
   .allowUnknownOption(true)
+  .allowExcessArguments(true)
   .action(prCreateCommand);
 
 // Handle unknown commands by passing them to git

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,9 +61,8 @@ program
   .option("-e, --edit", "edit the message after generation")
   .option("--no-edit", "do not edit the message after generation")
   .option("--dry-run", "generate and print the message but do not commit")
-  .option("--allow-empty")
-  .allowUnknownOption(true) // Pass through other git commit options
-  .allowExcessArguments(true) // ...including bare flags like --allow-empty
+  .allowUnknownOption(true) // pass through git flags like --allow-empty, --amend
+  .allowExcessArguments(true) // ...so bare passthrough flags don't error
   .action(commitCommand);
 
 program

--- a/src/services/git/executeGitCommit.ts
+++ b/src/services/git/executeGitCommit.ts
@@ -1,15 +1,17 @@
-import chalk from "chalk";
-import { execSync } from "child_process";
+import { spawnSync } from "child_process";
 
 export const executeGitCommit = (
   message: string,
-  additionalArgs: string[] = []
+  additionalArgs: string[] = [],
 ): void => {
-  try {
-    const args = additionalArgs.join(" ");
-    execSync(`git commit -m "${message}" ${args}`, { stdio: "inherit" });
-  } catch (error) {
-    console.error(chalk.red("Error committing changes:"), error);
+  // Pass args as an array (no shell) so messages or flags with spaces/quotes
+  // are never re-split or mis-escaped.
+  const result = spawnSync(
+    "git",
+    ["commit", "-m", message, ...additionalArgs],
+    { stdio: "inherit" },
+  );
+  if (result.status !== 0) {
     throw new Error("Failed to commit changes");
   }
 };

--- a/src/services/git/executeGitCommit.ts
+++ b/src/services/git/executeGitCommit.ts
@@ -4,13 +4,13 @@ export const executeGitCommit = (
   message: string,
   additionalArgs: string[] = [],
 ): void => {
+  const args = additionalArgs.filter((arg) => arg !== "commit");
+
   // Pass args as an array (no shell) so messages or flags with spaces/quotes
   // are never re-split or mis-escaped.
-  const result = spawnSync(
-    "git",
-    ["commit", "-m", message, ...additionalArgs],
-    { stdio: "inherit" },
-  );
+  const result = spawnSync("git", ["commit", "-m", message, ...args], {
+    stdio: "inherit",
+  });
   if (result.status !== 0) {
     throw new Error("Failed to commit changes");
   }

--- a/src/services/git/executeGitCommit.ts
+++ b/src/services/git/executeGitCommit.ts
@@ -4,13 +4,13 @@ export const executeGitCommit = (
   message: string,
   additionalArgs: string[] = [],
 ): void => {
-  const args = additionalArgs.filter((arg) => arg !== "commit");
-
   // Pass args as an array (no shell) so messages or flags with spaces/quotes
   // are never re-split or mis-escaped.
-  const result = spawnSync("git", ["commit", "-m", message, ...args], {
-    stdio: "inherit",
-  });
+  const result = spawnSync(
+    "git",
+    ["commit", "-m", message, ...additionalArgs],
+    { stdio: "inherit" },
+  );
   if (result.status !== 0) {
     throw new Error("Failed to commit changes");
   }

--- a/tests/unit/passthroughArgs.test.ts
+++ b/tests/unit/passthroughArgs.test.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "vitest";
+import type { Command } from "commander";
+import { passthroughArgs } from "../../src/commands/passthroughArgs.js";
+
+// "Falešná" command — napodobí jen to, co passthroughArgs potřebuje:
+//   .args   = tokeny navíc (co uživatel napsal a nejsou to gitpt options)
+//   .name() = jméno příkazu (např. "commit")
+// `as unknown as Command` jen řekne TypeScriptu: "ber to jako command".
+const fakeCommand = (args: string[] | undefined, name = "commit") =>
+  ({ args, name: () => name }) as unknown as Command;
+
+test("předá průchozí flag jako --allow-empty", () => {
+  expect(passthroughArgs(fakeCommand(["--allow-empty"]))).toEqual(["--allow-empty"]);
+});
+
+test("předá víc flagů najednou", () => {
+  expect(passthroughArgs(fakeCommand(["--allow-empty", "--no-verify"]))).toEqual([
+    "--allow-empty",
+    "--no-verify",
+  ]);
+});
+
+test("odfiltruje vlastní jméno příkazu (commit)", () => {
+  expect(passthroughArgs(fakeCommand(["commit", "--amend"]))).toEqual(["--amend"]);
+});
+
+test("vrátí prázdné pole, když nejsou žádné argumenty", () => {
+  expect(passthroughArgs(fakeCommand(undefined))).toEqual([]);
+});


### PR DESCRIPTION
filipbarta@macbook-server GitPT %  git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
filipbarta@macbook-server GitPT % git pull
Already up to date.
filipbarta@macbook-server GitPT % git checkout -b fix/commit-passthrough-flags

Switched to a new branch 'fix/commit-passthrough-flags'
filipbarta@macbook-server GitPT % npm run build

> gitpt@1.6.1 build
> tsc

filipbarta@macbook-server GitPT % gitpt commit --allow-empty
Error: No staged changes
filipbarta@macbook-server GitPT % gitpt add .
filipbarta@macbook-server GitPT % gitpt commit --no-edit
Generating commit message...
Commitlint configuration detected. Generating message according to rules...
Validating commit message against commitlint rules...
✓ Commit message passed validation
✓ Commit message generated

Generated message:
feat: allow unknown args and improve git command execution

[fix/commit-passthrough-flags 2bf94c0] feat: allow unknown args and improve git command execution
 3 files changed, 20 insertions(+), 19 deletions(-)
✓ Changes committed successfully
filipbarta@macbook-server GitPT % git commit --amend -m "fix: pass git flags through to git commit (EDITORS-85)"
[fix/commit-passthrough-flags d7bdca9] fix: pass git flags through to git commit (EDITORS-85)
 Date: Tue Jun 23 13:01:23 2026 +0200
 3 files changed, 20 insertions(+), 19 deletions(-)
filipbarta@macbook-server GitPT % git push -u origin fix/commit-passthrough-flags
Enumerating objects: 19, done.
Counting objects: 100% (19/19), done.
Delta compression using up to 10 threads
Compressing objects: 100% (10/10), done.
Writing objects: 100% (10/10), 1.44 KiB | 1.44 MiB/s, done.
Total 10 (delta 6), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (6/6), completed with 6 local objects.
remote: 
remote: Create a pull request for 'fix/commit-passthrough-flags' on GitHub by visiting:
remote:      https://github.com/bartaxyz/GitPT/pull/new/fix/commit-passthrough-flags
remote: 
To https://github.com/bartaxyz/GitPT
 * [new branch]      fix/commit-passthrough-flags -> fix/commit-passthrough-flags
branch 'fix/commit-passthrough-flags' set up to track 'origin/fix/commit-passthrough-flags'.
filipbarta@macbook-server GitPT % 