### PR TITLE
feat: add commit confirm/regenerate menu (EDITORS-89)

### DIFF
--- a/src/commands/commit/index.ts
+++ b/src/commands/commit/index.ts
@@ -24,7 +24,6 @@ export const commitCommand = async (options: CommitOptions): Promise<void> => {
   hasStagedChangesMiddleware();
 
   let commitMessage: string;
-  // Kept around so "Generate another" can re-run generation with a variation.
   let context: string | undefined;
 
   // If message is provided, use that

--- a/src/commands/commit/index.ts
+++ b/src/commands/commit/index.ts
@@ -24,6 +24,8 @@ export const commitCommand = async (options: CommitOptions): Promise<void> => {
   hasStagedChangesMiddleware();
 
   let commitMessage: string;
+  // Kept around so "Generate another" can re-run generation with a variation.
+  let context: string | undefined;
 
   // If message is provided, use that
   if (options.message) {
@@ -33,7 +35,7 @@ export const commitCommand = async (options: CommitOptions): Promise<void> => {
       // Get staged changes
       const diff = git.getStagedChanges();
 
-      const context = await prepareCommitContext(diff);
+      context = await prepareCommitContext(diff);
 
       console.log(chalk.blue("Generating commit message..."));
 
@@ -179,56 +181,68 @@ export const commitCommand = async (options: CommitOptions): Promise<void> => {
     return;
   }
 
-  // If edit is true or not specified, prompt user to edit the message
-  if (options.edit !== false) {
-    const answer = await inquirer.prompt([
-      {
-        type: "editor",
-        name: "message",
-        message: "Edit commit message:",
-        default: commitMessage,
-      },
-    ]);
+  // Interactive: confirm the message, regenerate a different one, edit, or
+  // cancel — one menu, looping until the user settles. Skipped for --no-edit
+  // (take the generated message) and -m (the user's own message).
+  if (options.edit !== false && !options.message && context !== undefined) {
+    let confirmed = false;
+    while (!confirmed) {
+      const { action } = await inquirer.prompt([
+        {
+          type: "list",
+          name: "action",
+          message: "Use this commit message?",
+          choices: [
+            { name: "Confirm and commit", value: "confirm" },
+            { name: "Generate another (different wording)", value: "another" },
+            { name: "Edit manually", value: "edit" },
+            { name: "Cancel", value: "cancel" },
+          ],
+        },
+      ]);
 
-    commitMessage = answer.message;
+      if (action === "confirm") {
+        confirmed = true;
+      } else if (action === "another") {
+        commitMessage = (
+          await generateCommitMessage(
+            `${context}\n\nWrite a noticeably different commit message — a fresh wording or angle, not the same as before.`,
+          )
+        ).trim();
+        console.log("");
+        console.log(chalk.cyan("Generated message:"));
+        console.log(commitMessage);
+        console.log("");
+      } else if (action === "edit") {
+        const answer = await inquirer.prompt([
+          {
+            type: "editor",
+            name: "message",
+            message: "Edit commit message:",
+            default: commitMessage,
+          },
+        ]);
+        commitMessage = answer.message;
+        confirmed = true;
+      } else {
+        console.log(chalk.gray("Commit cancelled."));
+        process.exit(0);
+      }
+    }
 
-    // Validate the edited message once
+    // Validate the final message; warn (never block) if it fails commitlint.
     try {
-      const hasCommitlint = hasCommitlintConfig();
-      if (hasCommitlint) {
-        console.log(chalk.blue("Validating edited commit message..."));
+      if (hasCommitlintConfig()) {
         const validation = await validateCommitMessage(commitMessage);
         if (!validation.valid) {
           console.log(
-            chalk.yellow("Warning: Edited message still has validation issues.")
+            chalk.yellow("Warning: the commit message has validation issues."),
           );
-          if (validation.errors) {
-            console.log(chalk.gray(validation.errors));
-          }
-
-          // Ask if user wants to proceed anyway
-          const { proceed } = await inquirer.prompt([
-            {
-              type: "confirm",
-              name: "proceed",
-              message: "Proceed with invalid commit message?",
-              default: false,
-            },
-          ]);
-
-          if (!proceed) {
-            console.log(chalk.red("Commit aborted by user."));
-            process.exit(1);
-          }
-        } else {
-          console.log(chalk.green("✓ Edited message passed validation"));
+          if (validation.errors) console.log(chalk.gray(validation.errors));
         }
       }
-    } catch (error) {
-      // If validation fails, just warn and continue
-      console.warn(
-        chalk.yellow("Could not validate edited message, proceeding anyway.")
-      );
+    } catch {
+      // Never block the commit on a validation hiccup.
     }
   }
 


### PR DESCRIPTION
filipbarta@macbook-server GitPT % git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
filipbarta@macbook-server GitPT % git pull
Already up to date.
filipbarta@macbook-server GitPT % git checkout -b feat/commit-confirm-or-next
Switched to a new branch 'feat/commit-confirm-or-next'
filipbarta@macbook-server GitPT %  npm run build

> gitpt@1.6.1 build
> tsc

filipbarta@macbook-server GitPT % gitpt add .
filipbarta@macbook-server GitPT %  gitpt commit
Generating commit message...
Commitlint configuration detected. Generating message according to rules...
Validating commit message against commitlint rules...
✓ Commit message passed validation
✓ Commit message generated

Generated message:
refactor: enhance commit message generation and validation loop

✔ Use this commit message? Confirm and commit
[feat/commit-confirm-or-next 6ab95b0] refactor: enhance commit message generation and validation loop
 1 file changed, 56 insertions(+), 42 deletions(-)
✓ Changes committed successfully
filipbarta@macbook-server GitPT % git reset scratch.txt && rm scratch.txt
fatal: ambiguous argument 'scratch.txt': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
filipbarta@macbook-server GitPT % git commit --amend -m "feat: add commit confirm/regenerate menu (EDITORS-89)"
[feat/commit-confirm-or-next 8b2ef6a] feat: add commit confirm/regenerate menu (EDITORS-89)
 Date: Tue Jun 23 13:52:18 2026 +0200
 1 file changed, 56 insertions(+), 42 deletions(-)
filipbarta@macbook-server GitPT % git push -u origin feat/commit-confirm-or-next
Enumerating objects: 11, done.
Counting objects: 100% (11/11), done.
Delta compression using up to 10 threads
Compressing objects: 100% (6/6), done.
Writing objects: 100% (6/6), 1.30 KiB | 1.30 MiB/s, done.
Total 6 (delta 5), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (5/5), completed with 5 local objects.
remote: 
remote: Create a pull request for 'feat/commit-confirm-or-next' on GitHub by visiting:
remote:      https://github.com/bartaxyz/GitPT/pull/new/feat/commit-confirm-or-next
remote: 
To https://github.com/bartaxyz/GitPT
 * [new branch]      feat/commit-confirm-or-next -> feat/commit-confirm-or-next
branch 'feat/commit-confirm-or-next' set up to track 'origin/feat/commit-confirm-or-next'.
filipbarta@macbook-server GitPT % 