### PR TITLE
feat: implement unified benchmarking across all supported models (EDITORS-84)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:apple": "npm run build && node tests/apple-foundation-models/run.mjs",
     "bench:apple": "npm run build && node tests/apple-foundation-models/benchmark.mjs",
     "bench:local": "npm run build && node tests/local-model/run.mjs",
+    "bench:all": "npm run build && node tests/run-all.mjs",
     "check:prompt": "npm run build && node tests/snapshots/check.mjs",
     "build:demo": "node scripts/build-demo.mjs",
     "prepublishOnly": "npm run build"

--- a/tests/local-model/run.mjs
+++ b/tests/local-model/run.mjs
@@ -1,11 +1,8 @@
 import { existsSync } from "fs";
 import { join } from "path";
 import chalk from "chalk";
-import {
-  distDir,
-  importDist,
-  runBenchmark,
-} from "../apple-foundation-models/harness.mjs";
+import { distDir, runBenchmark } from "../apple-foundation-models/harness.mjs";
+import { localModelStatus } from "./status.mjs";
 
 if (!existsSync(join(distDir, "config.js"))) {
   console.error(
@@ -14,67 +11,27 @@ if (!existsSync(join(distDir, "config.js"))) {
   process.exit(1);
 }
 
-const { getConfig } = await importDist("config.js");
-const { customLLMEndpoint: endpoint, model } = getConfig();
+const status = await localModelStatus();
 
-// The benchmark is pinned to one model. Default to the configured one; allow
-// an explicit override (e.g. when benchmarking a different local model).
-const expected = process.env.BENCH_MODEL || model;
-
-if (!endpoint || !expected) {
-  console.log(
-    chalk.yellow(
-      "SKIPPED: no local endpoint/model configured. Run `gitpt setup` first.",
-    ),
-  );
+// No reachable server / nothing configured → skip (don't fail), like Apple in CI.
+if (status.state === "skip") {
+  console.log(chalk.yellow(`SKIPPED: ${status.reason}.`));
   process.exit(0);
 }
 
-// Ask the local server which models it has and which is loaded.
-const fetchModels = async () => {
-  try {
-    const origin = new URL(endpoint).origin;
-    const res = await fetch(`${origin}/api/v0/models`);
-    if (!res.ok) return null;
-    return (await res.json())?.data ?? [];
-  } catch {
-    return null;
-  }
-};
-
-const models = await fetchModels();
-
-// No reachable server → skip (like the Apple runner in CI), don't fail.
-if (models === null) {
-  console.log(
-    chalk.yellow(
-      `SKIPPED: local LLM server not reachable at ${endpoint}. Start LM Studio.`,
-    ),
-  );
-  process.exit(0);
-}
-
-// Server is up but the expected model isn't the loaded one → hard fail: the
-// benchmark must run against exactly the model it claims to measure.
-const expectedLoaded = models.some(
-  (m) => m.id === expected && m.state === "loaded",
-);
-if (!expectedLoaded) {
-  const loaded =
-    models
-      .filter((m) => m.state === "loaded")
-      .map((m) => m.id)
-      .join(", ") || "(none)";
+// Server is up but the expected model isn't loaded → hard fail: this benchmark
+// is pinned and must run against exactly the model it claims to measure.
+if (status.state === "wrong-model") {
+  console.error(chalk.red(`Wrong model loaded — ${status.reason}.`));
   console.error(
-    chalk.red(`Expected model "${expected}" is not the loaded model.`),
+    chalk.gray("Load the expected model in LM Studio (or set BENCH_MODEL)."),
   );
-  console.error(chalk.gray(`Loaded: ${loaded}. Load it in LM Studio (or set BENCH_MODEL).`));
   process.exit(1);
 }
 
 const passed = await runBenchmark({
-  label: `Local LLM (${expected})`,
-  config: { provider: "local", model: expected, customLLMEndpoint: endpoint },
+  label: `Local LLM (${status.expected})`,
+  config: status.config,
 });
 
 process.exit(passed ? 0 : 1);

--- a/tests/local-model/status.mjs
+++ b/tests/local-model/status.mjs
@@ -1,0 +1,53 @@
+import { importDist } from "../apple-foundation-models/harness.mjs";
+
+/**
+ * Resolve whether the local-model benchmark can run, shared by the local runner
+ * and the run-all runner so the availability logic lives in one place.
+ *
+ * Returns one of:
+ *   { state: "ready", expected, endpoint, config }  → safe to benchmark
+ *   { state: "skip", reason }                        → not configured / server down
+ *   { state: "wrong-model", reason }                 → server up, expected model not loaded
+ */
+export const localModelStatus = async () => {
+  const { getConfig } = await importDist("config.js");
+  const { customLLMEndpoint: endpoint, model } = getConfig();
+
+  // Pinned to one model; default to the configured one, allow an override.
+  const expected = process.env.BENCH_MODEL || model;
+
+  if (!endpoint || !expected) {
+    return {
+      state: "skip",
+      reason: "no local endpoint/model configured (run `gitpt setup`)",
+    };
+  }
+
+  let models = null;
+  try {
+    const origin = new URL(endpoint).origin;
+    const res = await fetch(`${origin}/api/v0/models`);
+    if (res.ok) models = (await res.json())?.data ?? [];
+  } catch {
+    models = null;
+  }
+
+  if (models === null) {
+    return { state: "skip", reason: `local server not reachable at ${endpoint}` };
+  }
+
+  const loaded = models.filter((m) => m.state === "loaded").map((m) => m.id);
+  if (!loaded.includes(expected)) {
+    return {
+      state: "wrong-model",
+      reason: `expected "${expected}" but loaded: ${loaded.join(", ") || "(none)"}`,
+    };
+  }
+
+  return {
+    state: "ready",
+    expected,
+    endpoint,
+    config: { provider: "local", model: expected, customLLMEndpoint: endpoint },
+  };
+};

--- a/tests/run-all.mjs
+++ b/tests/run-all.mjs
@@ -1,0 +1,59 @@
+import { existsSync } from "fs";
+import { join } from "path";
+import chalk from "chalk";
+import {
+  distDir,
+  isSupported,
+  runBenchmark,
+} from "./apple-foundation-models/harness.mjs";
+import { localModelStatus } from "./local-model/status.mjs";
+
+if (!existsSync(join(distDir, "config.js"))) {
+  console.error(
+    chalk.red("dist/ not built. Run `npm run bench:all` (it builds first)."),
+  );
+  process.exit(1);
+}
+
+// Registry of models to benchmark. Unavailable ones are skipped (not failed).
+const runners = [];
+
+if (isSupported()) {
+  runners.push({
+    label: "Apple Foundation Models",
+    config: { provider: "apple", model: "system" },
+  });
+} else {
+  console.log(
+    chalk.yellow("SKIPPED Apple Foundation Models: needs the `fm` CLI on macOS 27+."),
+  );
+}
+
+const local = await localModelStatus();
+if (local.state === "ready") {
+  runners.push({
+    label: `Local LLM (${local.expected})`,
+    config: local.config,
+  });
+} else {
+  console.log(chalk.yellow(`SKIPPED Local LLM: ${local.reason}.`));
+}
+
+if (runners.length === 0) {
+  console.log(chalk.yellow("\nNo models available to benchmark."));
+  process.exit(0);
+}
+
+const results = [];
+for (const runner of runners) {
+  const passed = await runBenchmark(runner);
+  results.push({ label: runner.label, passed });
+}
+
+console.log(chalk.bold.underline("\nAll-models summary"));
+for (const { label, passed } of results) {
+  console.log("  " + (passed ? chalk.green("PASS ") : chalk.red("FAIL ")) + label);
+}
+
+// Non-zero only when an available model hard-failed.
+process.exit(results.some((r) => !r.passed) ? 1 : 0);


### PR DESCRIPTION
```filipbarta@macbook-server GitPT % BENCH_FILTER=01 npm run bench:local

> gitpt@1.6.1 bench:local
> npm run build && node tests/local-model/run.mjs


> gitpt@1.6.1 build
> tsc


Local LLM (google/gemma-4-e4b) — commit message benchmark

Unit: token counting and context window
  PASS [hard] context window is positive (8192)
  PASS [hard] countTokens is positive for non-empty input
  PASS [hard] countTokens grows with input length

Fixture: 01-real-bugfix-endpoint.patch
  . origin: 0f52473
  . reference message: fix: llm provider endpoint resolution
  . should mention: fixing provider/endpoint resolution
  . diff tokens: 218
  . over budget: false
  PASS [hard] diff fits, so context is returned unchanged
  . commit message: feat: add provider support for local LLMs
  PASS [soft] guardrail: valid conventional subject (<=72, single line)
  WARN [soft] type is one of [fix] (got 'feat')
  PASS [soft] mentions one of [endpoint, provider, resolution, url]

Summary
  hard: 4 passed, 0 failed
  soft: 2 passed, 1 warned (quality, non-deterministic - review manually)
filipbarta@macbook-server GitPT % gitpt add .
filipbarta@macbook-server GitPT % gitpt commit --no-edit
✔ Summarized 4 file(s) to fit the context window: ~5205 → ~180 tokens
Generating commit message...
Commitlint configuration detected. Generating message according to rules...
Validating commit message against commitlint rules...
✓ Commit message passed validation
✓ Commit message generated

Generated message:
test: implement unified benchmarking setup and runners

[test/local-model-benchmark 1d1fa47] test: implement unified benchmarking setup and runners
 4 files changed, 230 insertions(+), 129 deletions(-)
 create mode 100644 tests/local-model/run.mjs
✓ Changes committed successfully
filipbarta@macbook-server GitPT % git push -u origin test/local-model-benchmark

Enumerating objects: 15, done.
Counting objects: 100% (15/15), done.
Delta compression using up to 10 threads
Compressing objects: 100% (8/8), done.
Writing objects: 100% (9/9), 4.63 KiB | 4.63 MiB/s, done.
Total 9 (delta 4), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (4/4), completed with 4 local objects.
remote: 
remote: Create a pull request for 'test/local-model-benchmark' on GitHub by visiting:
remote:      https://github.com/bartaxyz/GitPT/pull/new/test/local-model-benchmark
remote: 
To https://github.com/bartaxyz/GitPT
 * [new branch]      test/local-model-benchmark -> test/local-model-benchmark
branch 'test/local-model-benchmark' set up to track 'origin/test/local-model-benchmark'.
filipbarta@macbook-server GitPT % clear

filipbarta@macbook-server GitPT %  git checkout -b test/run-all-benchmarks
Switched to a new branch 'test/run-all-benchmarks'
filipbarta@macbook-server GitPT %  BENCH_FILTER=01 npm run bench:all

> gitpt@1.6.1 bench:all
> npm run build && node tests/run-all.mjs


> gitpt@1.6.1 build
> tsc

SKIPPED Apple Foundation Models: needs the `fm` CLI on macOS 27+.

Local LLM (google/gemma-4-e4b) — commit message benchmark

Unit: token counting and context window
  PASS [hard] context window is positive (8192)
  PASS [hard] countTokens is positive for non-empty input
  PASS [hard] countTokens grows with input length

Fixture: 01-real-bugfix-endpoint.patch
  . origin: 0f52473
  . reference message: fix: llm provider endpoint resolution
  . should mention: fixing provider/endpoint resolution
  . diff tokens: 218
  . over budget: false
  PASS [hard] diff fits, so context is returned unchanged
  . commit message: feat: allow specifying provider and custom endpoint for LLM client
  PASS [soft] guardrail: valid conventional subject (<=72, single line)
  WARN [soft] type is one of [fix] (got 'feat')
  PASS [soft] mentions one of [endpoint, provider, resolution, url]

Summary
  hard: 4 passed, 0 failed
  soft: 2 passed, 1 warned (quality, non-deterministic - review manually)

All-models summary
  PASS Local LLM (google/gemma-4-e4b)
filipbarta@macbook-server GitPT % gitpt add .
filipbarta@macbook-server GitPT % gitpt commit --no-edit
Generating commit message...
Commitlint configuration detected. Generating message according to rules...
Validating commit message against commitlint rules...
✓ Commit message passed validation
✓ Commit message generated

Generated message:
feat: implement unified benchmarking across all supported models

[test/run-all-benchmarks 15a3ff6] feat: implement unified benchmarking across all supported models
 4 files changed, 126 insertions(+), 56 deletions(-)
 create mode 100644 tests/local-model/status.mjs
 create mode 100644 tests/run-all.mjs
✓ Changes committed successfully
filipbarta@macbook-server GitPT % git push -u origin test/run-all-benchmarks
Enumerating objects: 13, done.
Counting objects: 100% (13/13), done.
Delta compression using up to 10 threads
Compressing objects: 100% (8/8), done.
Writing objects: 100% (8/8), 2.59 KiB | 2.59 MiB/s, done.
Total 8 (delta 3), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (3/3), completed with 3 local objects.
remote: 
remote: Create a pull request for 'test/run-all-benchmarks' on GitHub by visiting:
remote:      https://github.com/bartaxyz/GitPT/pull/new/test/run-all-benchmarks
remote: 
To https://github.com/bartaxyz/GitPT
 * [new branch]      test/run-all-benchmarks -> test/run-all-benchmarks
branch 'test/run-all-benchmarks' set up to track 'origin/test/run-all-benchmarks'.
filipbarta@macbook-server GitPT % 
```