### PR TITLE
feat: implement dynamic token budgeting for context window fitting (EDITOR-92)

### DIFF
--- a/src/commands/commit/summarizeDiff.ts
+++ b/src/commands/commit/summarizeDiff.ts
@@ -1,11 +1,11 @@
 import ora from "ora";
 import { getProvider } from "../../llm/registry.js";
 import { countTokens } from "../../llm/tokenCount.js";
+import { fitBudget } from "../../llm/budget.js";
 import { summarySystemPrompt, summaryUserPrompt } from "./context/summaryPrompt.js";
 import { systemPrompt } from "./context/systemPrompt.js";
 import { userPrompt } from "./context/userPrompt.js";
 
-const MARGIN = 0.9;
 const MAX_REDUCE_PASSES = 3;
 
 const LOW_SIGNAL_PATTERNS: Array<{ test: RegExp; note: string }> = [
@@ -141,8 +141,8 @@ export const prepareCommitContext = async (diff: string): Promise<string> => {
   const window = await getProvider().getContextWindow();
   if (!Number.isFinite(window)) return diff;
 
-  const fitBudget = Math.floor((window - reserved) * MARGIN);
-  if (finalPromptTokens(diff) <= fitBudget) return diff;
+  const promptBudget = fitBudget(window, reserved);
+  if (finalPromptTokens(diff) <= promptBudget) return diff;
 
   const spinner = ora({ text: "Analyzing diff size..." }).start();
 
@@ -165,9 +165,7 @@ export const prepareCommitContext = async (diff: string): Promise<string> => {
     const summaryOverhead = countTokens(
       `${summarySystemPrompt}\n\n${summaryUserPrompt("")}`
     );
-    const chunkBudget = Math.floor(
-      (window - reserved - summaryOverhead) * MARGIN
-    );
+    const chunkBudget = fitBudget(window, reserved + summaryOverhead);
 
     const chunks = packChunks(sourceBlocks, chunkBudget);
     const condensedNote = lowSignalLines.length
@@ -188,7 +186,7 @@ export const prepareCommitContext = async (diff: string): Promise<string> => {
     const framed = () => `${header}\n${combined}`;
 
     let pass = 0;
-    while (finalPromptTokens(framed()) > fitBudget && pass < MAX_REDUCE_PASSES) {
+    while (finalPromptTokens(framed()) > promptBudget && pass < MAX_REDUCE_PASSES) {
       pass++;
       const lineBlocks: Block[] = combined
         .split("\n")
@@ -208,9 +206,9 @@ export const prepareCommitContext = async (diff: string): Promise<string> => {
       combined = reduced.filter(Boolean).join("\n");
     }
 
-    if (finalPromptTokens(framed()) > fitBudget) {
+    if (finalPromptTokens(framed()) > promptBudget) {
       const headerTokens = countTokens(`${systemPrompt}\n\n${userPrompt(`${header}\n`)}`);
-      combined = truncateToBudget("summary", combined, fitBudget - headerTokens);
+      combined = truncateToBudget("summary", combined, promptBudget - headerTokens);
     }
 
     spinner.succeed(

--- a/src/llm/budget.ts
+++ b/src/llm/budget.ts
@@ -1,0 +1,13 @@
+// Jeden zdroj pravdy pro výpočet, kolik tokenů promptu se vejde do okna.
+// Sdílí ho produkce (summarizeDiff.ts) i benchmark (harness.mjs), aby se
+// nemohly rozejít (viz EDITORS-84 / EDITORS-92).
+
+/** Rezerva: necháme 10 % použitelného okna jako bezpečnostní polštář. */
+export const MARGIN = 0.9;
+
+/**
+ * Maximální počet tokenů promptu, který se vejde do `window`,
+ * když si necháme `reserved` tokenů na odpověď modelu.
+ */
+export const fitBudget = (window: number, reserved: number): number =>
+  Math.floor((window - reserved) * MARGIN);

--- a/src/llm/tokenCount.ts
+++ b/src/llm/tokenCount.ts
@@ -1,7 +1,5 @@
 import { getProvider } from "./registry.js";
 
-export const RESERVED_OUTPUT_TOKENS = 1024;
-
 export const countTokens = (text: string): number =>
   getProvider().countTokens(text);
 

--- a/tests/apple-foundation-models/harness.mjs
+++ b/tests/apple-foundation-models/harness.mjs
@@ -114,8 +114,10 @@ export const runBenchmark = async ({ label, config }) => {
   const { generateCommitMessage } = await importDist(
     "commands/commit/generateCommitMessage.js",
   );
-  const { countTokens, getContextWindow, RESERVED_OUTPUT_TOKENS } =
+  const { countTokens, getContextWindow } =
     await importDist("llm/tokenCount.js");
+  const { fitBudget } = await importDist("llm/budget.js");
+  const { getProvider } = await importDist("llm/registry.js");
   const { systemPrompt } = await importDist(
     "commands/commit/context/systemPrompt.js",
   );
@@ -127,7 +129,7 @@ export const runBenchmark = async ({ label, config }) => {
 
   return withConfig(config, async () => {
     const contextWindow = await getContextWindow();
-    const promptBudget = Math.floor((contextWindow - RESERVED_OUTPUT_TOKENS) * 0.9);
+    const promptBudget = fitBudget(contextWindow, getProvider().maxOutputTokens);
     const promptTokens = (context) =>
       countTokens(`${systemPrompt}\n\n${userPrompt(context)}`);
 

--- a/tests/unit/budget.test.ts
+++ b/tests/unit/budget.test.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "vitest";
+import { MARGIN, fitBudget } from "../../src/llm/budget.js";
+
+test("fitBudget = floor((window - reserved) * MARGIN)", () => {
+  expect(fitBudget(10000, 1024)).toBe(Math.floor((10000 - 1024) * MARGIN));
+});
+
+test("větší rezerva → menší rozpočet", () => {
+  expect(fitBudget(10000, 2000)).toBeLessThan(fitBudget(10000, 1024));
+});
+
+test("výsledek je celé číslo (zaokrouhlené dolů)", () => {
+  expect(Number.isInteger(fitBudget(8193, 1000))).toBe(true);
+});
+
+test("MARGIN je 0.9", () => {
+  expect(MARGIN).toBe(0.9);
+});


### PR DESCRIPTION
```filipbarta@macbook-server GitPT %  git checkout refactor/shared-budget-calc
Switched to branch 'refactor/shared-budget-calc'
filipbarta@macbook-server GitPT % npm run typecheck

> gitpt@1.6.1 typecheck
> tsc --noEmit

filipbarta@macbook-server GitPT % npm run build

> gitpt@1.6.1 build
> tsc

filipbarta@macbook-server GitPT % npm test

> gitpt@1.6.1 test
> vitest run


 RUN  v4.1.9 /Users/filipbarta/GitPT

 ✓ tests/unit/maskApiKey.test.ts (4 tests) 2ms
 ✓ tests/unit/formatBaseURL.test.ts (4 tests) 2ms
 ✓ tests/unit/budget.test.ts (4 tests) 2ms

 Test Files  3 passed (3)
      Tests  12 passed (12)
   Start at  16:23:12
   Duration  120ms (transform 55ms, setup 0ms, import 80ms, tests 5ms, environment 0ms)

filipbarta@macbook-server GitPT % git status
On branch refactor/shared-budget-calc
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   src/commands/commit/summarizeDiff.ts
	modified:   src/llm/tokenCount.ts
	modified:   tests/apple-foundation-models/harness.mjs

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	src/llm/budget.ts
	tests/unit/budget.test.ts

no changes added to commit (use "git add" and/or "git commit -a")
filipbarta@macbook-server GitPT %   git add -A                                
filipbarta@macbook-server GitPT % gitpt commit --no-edit
Generating commit message...
Commitlint configuration detected. Generating message according to rules...
Validating commit message against commitlint rules...
✓ Commit message passed validation
✓ Commit message generated

Generated message:
feat: implement dynamic token budgeting for context window fitting

[refactor/shared-budget-calc 07fcee7] feat: implement dynamic token budgeting for context window fitting
 5 files changed, 42 insertions(+), 13 deletions(-)
 create mode 100644 src/llm/budget.ts
 create mode 100644 tests/unit/budget.test.ts
✓ Changes committed successfully
filipbarta@macbook-server GitPT % git push -u origin refactor/shared-budget-calc
Enumerating objects: 25, done.
Counting objects: 100% (25/25), done.
Delta compression using up to 10 threads
Compressing objects: 100% (14/14), done.
Writing objects: 100% (14/14), 2.02 KiB | 2.02 MiB/s, done.
Total 14 (delta 9), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (9/9), completed with 9 local objects.
remote: 
remote: Create a pull request for 'refactor/shared-budget-calc' on GitHub by visiting:
remote:      https://github.com/bartaxyz/GitPT/pull/new/refactor/shared-budget-calc
remote: 
To https://github.com/bartaxyz/GitPT
 * [new branch]      refactor/shared-budget-calc -> refactor/shared-budget-calc
branch 'refactor/shared-budget-calc' set up to track 'origin/refactor/shared-budget-calc'.
filipbarta@macbook-server GitPT % ```
