### PR TITLE
ci: bump publish workflow to Node 22 and actions to v4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,16 +15,16 @@ jobs:
     
     steps:
       # Step 1: Check out the repository's code at the default branch
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.repository.default_branch }}
 
       # Step 2: Set up a Node.js environment and configure npm to use the official registry
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
 
       # Step 3: Install dependencies


### PR DESCRIPTION
The publish workflow ran on Node 18 which the Vite build no longer supports, so this bumps it to Node 22 and updates the checkout and setup-node actions to v4.