### PR TITLE
chore: update license copyright to 2026 Ondřej Bárta

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 @bartaxyz
+Copyright (c) 2026 Ondřej Bárta
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updates the LICENSE copyright year to 2026 and the holder to Ondřej Bárta.